### PR TITLE
Added clear riders and basic start light (#52 and #36)

### DIFF
--- a/CentralUnit/RaceManagement/RaceManager.cs
+++ b/CentralUnit/RaceManagement/RaceManager.cs
@@ -115,7 +115,6 @@ namespace RaceManagement
             startLight.SetStartLightColor(StartLightColor.YELLOW);
 
             startGate.AddKnownRiders(riders);
-            endGate.AddKnownRiders(riders);
 
             tracker = new RaceTracker(timing, startGate, endGate, config.ExtractTrackerConfig(), riders);
             HookEvents(tracker);


### PR DESCRIPTION
The startlight operation is way simpler than specified there, so we'll leave #36 open.